### PR TITLE
feat: Add <&&...> operators

### DIFF
--- a/src/Data/Functor/Syntax.hs
+++ b/src/Data/Functor/Syntax.hs
@@ -37,6 +37,38 @@ infixr 8 <$$$$>
 
 infixr 8 <$$$$$>
 
+(<&&>) :: (Functor f0, Functor f1) =>
+          f1 (f0 a)
+       -> (a -> b)
+       -> f1 (f0 b)
+(<&&>) = flip (fmap . fmap)
+
+infixl 1 <&&>
+
+(<&&&>) :: (Functor f0, Functor f1, Functor f2) =>
+          f2 (f1 (f0 a))
+       -> (a -> b)
+       -> f2 (f1 (f0 b))
+(<&&&>) = flip (fmap . fmap . fmap)
+
+infixl 1 <&&&>
+
+(<&&&&>) :: (Functor f0, Functor f1, Functor f2, Functor f3) =>
+          f3 (f2 (f1 (f0 a)))
+       -> (a -> b)
+       -> f3 (f2 (f1 (f0 b)))
+(<&&&&>) = flip (fmap . fmap . fmap . fmap)
+
+infixl 1 <&&&&>
+
+(<&&&&&>) :: (Functor f0, Functor f1, Functor f2, Functor f3, Functor f4) =>
+          f4 (f3 (f2 (f1 (f0 a))))
+       -> (a -> b)
+       -> f4 (f3 (f2 (f1 (f0 b))))
+(<&&&&&>) = flip (fmap . fmap . fmap . fmap . fmap)
+
+infixl 1 <&&&&&>
+
 -- * Nested Application
 
 (<$~>) :: Functor f0 =>


### PR DESCRIPTION
This adds `<&&...>`, being the flipped versions of `<$$...>`, just as `Data.Functor` exposes `<&>` as a flipped `<$>` in `base`.

I used `infixl 1`, as that matches `<&>`, which is contrary to the approach taken by `<$$...>`.  
Happy to discuss this decision.

```haskell
Just (Just 1)
  <&> fmap (+ 3)
  <&&> (+ 4)
-- Just (Just 8)
```

@athanclark 